### PR TITLE
Ensure npm install runs before tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,11 @@ jobs:
               if: steps.webview-cache.outputs.cache-hit != 'true'
               run: cd webview-ui && npm ci
 
+            - name: Ensure dependencies are installed
+              run: |
+                  npm install
+                  cd webview-ui && npm install
+
             - name: Type Check
               run: npm run check-types
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you're planning to work on a bigger feature, please create a [feature request
 
 2. **Local Development**
     - Run `npm run install:all` to install dependencies
-    - Run `npm run test` to run tests locally
+    - After installing dependencies, run `npm test` to run tests locally
     - Before submitting PR, run `npm run format:fix` to format your code
 
 ## Writing and Submitting Code


### PR DESCRIPTION
## Summary
- ensure workflows run `npm install` before tests
- note in contributing docs that tests require installed dependencies

## Testing
- `npm run format:fix`
- `npm test` *(fails: X server not available)*

------
https://chatgpt.com/codex/tasks/task_e_684170cf01808328a25bf69f39db0ef8